### PR TITLE
Fix for tf.keras: Cast input_dims to int.

### DIFF
--- a/SpectralNormalizationKeras.py
+++ b/SpectralNormalizationKeras.py
@@ -17,7 +17,7 @@ import tensorflow as tf
 class DenseSN(Dense):
     def build(self, input_shape):
         assert len(input_shape) >= 2
-        input_dim = input_shape[-1]
+        input_dim = int(input_shape[-1])
         self.kernel = self.add_weight(shape=(input_dim, self.units),
                                       initializer=self.kernel_initializer,
                                       name='kernel',
@@ -127,7 +127,7 @@ class _ConvSN(Layer):
         if input_shape[channel_axis] is None:
             raise ValueError('The channel dimension of the inputs '
                              'should be defined. Found `None`.')
-        input_dim = input_shape[channel_axis]
+        input_dim = int(input_shape[channel_axis])
         kernel_shape = self.kernel_size + (input_dim, self.filters)
 
         self.kernel = self.add_weight(shape=kernel_shape,
@@ -278,7 +278,7 @@ class ConvSN2D(Conv2D):
         if input_shape[channel_axis] is None:
             raise ValueError('The channel dimension of the inputs '
                              'should be defined. Found `None`.')
-        input_dim = input_shape[channel_axis]
+        input_dim = int(input_shape[channel_axis])
         kernel_shape = self.kernel_size + (input_dim, self.filters)
 
         self.kernel = self.add_weight(shape=kernel_shape,
@@ -357,7 +357,7 @@ class ConvSN1D(Conv1D):
         if input_shape[channel_axis] is None:
             raise ValueError('The channel dimension of the inputs '
                              'should be defined. Found `None`.')
-        input_dim = input_shape[channel_axis]
+        input_dim = int(input_shape[channel_axis])
         kernel_shape = self.kernel_size + (input_dim, self.filters)
 
         self.kernel = self.add_weight(shape=kernel_shape,
@@ -435,7 +435,7 @@ class ConvSN3D(Conv3D):
         if input_shape[channel_axis] is None:
             raise ValueError('The channel dimension of the inputs '
                              'should be defined. Found `None`.')
-        input_dim = input_shape[channel_axis]
+        input_dim = int(input_shape[channel_axis])
         kernel_shape = self.kernel_size + (input_dim, self.filters)
 
         self.kernel = self.add_weight(shape=kernel_shape,
@@ -569,7 +569,7 @@ class ConvSN2DTranspose(Conv2DTranspose):
         if input_shape[channel_axis] is None:
             raise ValueError('The channel dimension of the inputs '
                              'should be defined. Found `None`.')
-        input_dim = input_shape[channel_axis]
+        input_dim = int(input_shape[channel_axis])
         kernel_shape = self.kernel_size + (self.filters, input_dim)
 
         self.kernel = self.add_weight(shape=kernel_shape,


### PR DESCRIPTION
Currently, your code only works for regular Keras, but not for tf.keras, because input_shape is a tensor in Tensorflow. By simply casting all input_dim to int, your code should work for both Keras (where input_dim is already int) and tf.keras.

This is useful, because some TF functionalities (like efficient data loading) only work with tf.keras, and tf.keras and keras layers cannot be combined.

To see how imports have to be changed for tf.keras, see https://github.com/fa9r/SpectralNormalizationTensorflowKeras